### PR TITLE
Fixed toggled objects killing the player

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# V1.0.5
+- Fixed toggled objects killing the player
+
 # V1.0.4
 - Fixed wave hitboxes
 - Added missing spike ID (39)

--- a/mod.json
+++ b/mod.json
@@ -8,7 +8,7 @@
 	},
 	"id": "tyegurr.accurate-hitboxes",
 	"name": "Accurate Hitboxes",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"developer": "Tyegurr",
 	"tags": ["joke", "gameplay"],
 	"description": "Is GD possible with ACCURATE HITBOXES?",

--- a/src/hooks/GJBaseGameLayerHook.hpp
+++ b/src/hooks/GJBaseGameLayerHook.hpp
@@ -33,6 +33,11 @@ class $modify(GJBaseGameLayerHook, GJBaseGameLayer)
         {
             GameObject* gObj = objects->at(i);
 
+            // GameObject::m_isActivated seems to represent if an object is toggled
+            bool objHasBeenToggled = !gObj->m_isActivated;
+            if (objHasBeenToggled)
+                continue;
+
             CCPoint playerPos = object->getPosition();
             CCPoint objectPos = gObj->getPosition();
             CCSize objectContentSize = gObj->getContentSize();


### PR DESCRIPTION
Toggled objects killed the player, when it obviously shouldn't happen
When an objects get toggled off, gd seems to set `GameObject::m_isActivated` to `false`, I simply added a check for this